### PR TITLE
append to goyo_callbacks if it's already set

### DIFF
--- a/plugin/zenroom2.vim
+++ b/plugin/zenroom2.vim
@@ -87,4 +87,10 @@ function! s:zenroom_goyo_after()
     endif
 endfunction
 
-let g:goyo_callbacks = [ function('s:zenroom_goyo_before'), function('s:zenroom_goyo_after') ]
+" append to callbacks if they are already set. Otherwise set the callbacks.
+if exists('g:goyo_callbacks')
+  call add(g:goyo_callbacks, function('s:zenroom_goyo_before'))
+  call add(g:goyo_callbacks, function('s:zenroom_goyo_after'))
+else
+  let g:goyo_callbacks = [ function('s:zenroom_goyo_before'), function('s:zenroom_goyo_after') ]
+endif


### PR DESCRIPTION
this allows for setting custom goyo callbacks in addition to the zenroom ones. This is useful for adding workarounds like the one mentioned in https://github.com/junegunn/goyo.vim/issues/16. Right now those custom callbacks would get overwritten, this change makes it append the callbacks.